### PR TITLE
Fixing syntax in getAccessTokenData example

### DIFF
--- a/content/overview/userid.md
+++ b/content/overview/userid.md
@@ -17,11 +17,11 @@ That will save the user ID into the database with the access token. When the tok
 can retrieve the associated ID:
 
 ```php
-if (!$server->verifyResourceRequest(OAuth2_Request::createFromGlobals())) {
+if (!$server->verifyResourceRequest(OAuth2\Request::createFromGlobals())) {
     $server->getResponse()->send();
     die;
 }
 
-$token = $server->getAccessTokenData(OAuth2_Request::createFromGlobals());
+$token = $server->getAccessTokenData(OAuth2\Request::createFromGlobals());
 echo "User ID associated with this token is {$token['user_id']}";
 ```


### PR DESCRIPTION
using OAuth2_Request::createFromGlobals() causes a class redeclaration issue, changed it to OAuth2\Request::createFromGlobals().
