### PR TITLE
Fix documentation regarding getAccessTokenData().

### DIFF
--- a/content/controllers/resource.md
+++ b/content/controllers/resource.md
@@ -18,4 +18,4 @@ the incomming request is valid
 
 `getAccessTokenData`
 
-  * Takes a token string as an argument and returns the token data if applicable, or null if the token is invalid
+  * Takes a request object as an argument and returns the token data if applicable, or null if the token is invalid


### PR DESCRIPTION
Originally it was "token as a string" but this is incorrect because it results in this error: "Argument 1 passed to OAuth2\Server::getAccessTokenData() must implement interface OAuth2\RequestInterface, string given"
