### PR TITLE
Allow null for client_secret

### DIFF
--- a/content/cookbook/doctrine.md
+++ b/content/cookbook/doctrine.md
@@ -18,7 +18,7 @@ OAuthClient:
       notnull:    true
     client_secret:
       type:       char(20)
-      notnull:    true
+      notnull:    false
     redirect_uri:
       type:       string(255)
       notnull:    true


### PR DESCRIPTION
Changed `client_secret` declaration in schema to allow NULL values