### PR TITLE
Fixed dead links in openid-connect section

### DIFF
--- a/content/overview/openid-connect.md
+++ b/content/overview/openid-connect.md
@@ -7,9 +7,9 @@ title: OpenID Connect | OAuth2 Server PHP
 ## Examples
 
 You can see an example of OpenID Connect running on
-[the demo site](demo site) (select the `OpenID Connect` tab), and
-[the code used](use_openid_connect) to set this up using the
-`use_openid_connect` configuration option the [key storage](key_storage) object.
+[the demo site][demo site] (select the `OpenID Connect` tab), and
+[the code used][use_openid_connect] to set this up using the
+`use_openid_connect` configuration option the [key storage] object.
 
 ## Overview
 


### PR DESCRIPTION
Despite the excellent documentation and code examples the current state of the OpenID Connect section is quite confusing. This is caused by the dead links to the relevant sections of the source code and demo site leaving users behind with only the few code snippets on the page it self.

This PR fixes those dead links.