### PR TITLE
Fix the dead link for the Auth0 PHP implementation

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -55,7 +55,7 @@ and view the [source code](https://github.com/bshaffer/oauth2-demo-php) for exam
 [grant types](overview/grant-types).
 ![OAuth Demo Application](http://brentertainment.com/other/screenshots/demoapp-authorize.png)
 
-3. Also, [Auth0](https://auth0.com/) provides a very nice layer for implementing OAuth2.0 for [PHP applications](https://docs.auth0.com/server-platforms/php).
+3. Also, [Auth0](https://auth0.com/) provides a very nice layer for implementing OAuth2.0 for [PHP applications](https://auth0.com/docs/quickstart/webapp/php).
 
 4. Finally, consult the [official OAuth2.0 documentation](http://tools.ietf.org/html/rfc6749) for the down-and-dirty
 technical specifications.


### PR DESCRIPTION
The previously linked page, https://docs.auth0.com/server-platforms/php , is no longer available at the time of writing.

This commit changes it to https://auth0.com/docs/quickstart/webapp/php , a page which contains information about using Auth0 with PHP.