### PR TITLE
Add grant type for OpenID Connect to $server

### DIFF
--- a/content/overview/openid-connect.md
+++ b/content/overview/openid-connect.md
@@ -76,6 +76,14 @@ CREATE TABLE oauth_public_keys (
 
 >
 
+### 5\. Create OpenID grant type and add it to the server:
+
+```php
+$server->addGrantType ( new OAuth2\OpenID\GrantType\AuthorizationCode ( $storage ) );
+```
+
+>
+
 ## Verify OpenID Connect
 
 If your server is properly configured for OpenID Connect, when you request an


### PR DESCRIPTION
Updated documentation for OpenID Connect to add grant type.

Fixes #74. This will help a lot of people struggling with this missing line of code.