### PR TITLE
yml heading not visible enough

### DIFF
--- a/content/css/coderay.css
+++ b/content/css/coderay.css
@@ -65,7 +65,7 @@ ol.CodeRay li { white-space: pre }
 .CodeRay .doc-string { color:#D42; font-weight:bold }
 .CodeRay .escape  { color:#666; font-weight:bold }
 .CodeRay .entity { color:#800; font-weight:bold }
-.CodeRay .error { color:#F00; background-color:#FAA }
+.CodeRay .error {  color: #fafafb; background-color: #d14;}
 .CodeRay .exception { color:#C00; font-weight:bold }
 .CodeRay .filename { color:#099; }
 .CodeRay .function { color:#900; font-weight:bold }


### PR DESCRIPTION
yml heading on documentation at "cookbook/doctrine2/", not visible enough